### PR TITLE
Added "espruino.com/webide?codefile=.." support

### DIFF
--- a/js/plugins/urlHandler.js
+++ b/js/plugins/urlHandler.js
@@ -19,8 +19,13 @@
   function handleQuery(key, val) {
     Espruino.Core.Code.switchToCode(); // if in blockly
     switch(key){
-      case "code":
+      case "code": // Tef edit: when passing "encodedURIcomponent code" within the URL
         Espruino.Core.EditorJavaScript.setCode(val);
+        break;
+      case "codefile": // Tef edit: ADDITION: when passing a file URL within the URL :)
+        $.ajax({ url: val, cache: false }).done(function( data ) { 
+          Espruino.Core.EditorJavaScript.setCode(data);
+        });
         break;
       case "upload":
         Espruino.Core.MenuPortSelector.ensureConnected(function() {


### PR DESCRIPTION
Now handles ```"http://www.espruino.com/webide?codefile=.."``` additionally to handling ```"http://www.espruino.com/webide?code=.."```

In other words, we can now pass a file url which we'll get content from, instead of the URI-component-encoded file content as part of th URL. Should be handy for linking to stuff wihout js available ( ex: Github )

Quoting +Gordon: "Nice idea! That should be pretty easy to add."
Well: "Niceties added" ! ;P

Now: let's have that Cake ! "Load this into Espruino" buttons everywhere !! :D

Keep up the good work,
Cheers +