### PR TITLE
fix: close serial connections right on window close, do not wait for suspend

### DIFF
--- a/js/background.js
+++ b/js/background.js
@@ -18,6 +18,18 @@ chrome.app.runtime.onLaunched.addListener(function(launchData) {
         });
       });
     });
+    // ---------------------------------------------------------- CLOSE SERIAL ON EXIT
+    win.onClosed.addListener(function() {
+      // Background script keeps running even after window close
+      // for a few seconds. So serial connection keeped open and
+      // we can't connect to the board again after quick IDE restart
+      chrome.serial.getConnections(function(connections) {
+        connections.forEach(function(c) {
+          chrome.serial.disconnect(c.connectionId, function() {});
+        });
+      });
+    });
+
     // ---------------------------------------------------------- URL LAUNCH
     if (launchData.id) {
       // We are called to handle a URL that matches one of our url_handlers.


### PR DESCRIPTION
For now serial connection is keeped alive by Chrome’s background.js even after IDE window close. So if one would close connected IDE and launch it again within few seconds serial connection will be occupied and he will have no chance to connect again without Chrome restart.

The bug is related to Windows.