### PR TITLE
fix: refresh CodeMirror on font size change

### DIFF
--- a/js/plugins/fontSize.js
+++ b/js/plugins/fontSize.js
@@ -27,6 +27,7 @@
   
   function setFontSize(size) {
     $("#terminal,.CodeMirror").css("font-size", size+"px");
+    Espruino.Core.EditorJavaScript.getCodeMirror().refresh();
   }
   
   Espruino.Plugins.FontSize = {


### PR DESCRIPTION
![image](https://cloud.githubusercontent.com/assets/146383/14177490/2f02cd5e-f75f-11e5-86fa-675de537c9d9.png)

Changes of font size lead to a wrong left margin in editor. This is fixed now.