### PR TITLE
update name

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "espruino-web-ide",
+  "name": "Espruino Web IDE",
   "version": "0.64.2",
   "description": "A Terminal and Graphical code Editor for Espruino JavaScript Microcontrollers",
   "//1": "-------------------------------------------------------- nw.js",


### PR DESCRIPTION
Since Web Bluetooth chooser uses package name, it might be nice to have a proper and readable package name. WDYT?
