### PR TITLE
Typo fix at documentation: "Chromne" -> "Chrome"

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,7 +58,7 @@ This will clone both the EspruinoWebIDE repository and the submodule dependencie
 * Download the files in [EspruinoWebIDE](https://github.com/espruino/EspruinoWebIDE) to an `EspruinoWebIDE` directory on your PC (either as a [ZIP File](https://github.com/espruino/EspruinoWebIDE/archive/gh-pages.zip), or using git)
 * Download the files in [EspruinoTools](https://github.com/espruino/EspruinoTools) into the `EspruinoWebIDE/EspruinoTools` on your PC (either as a [ZIP File](https://github.com/espruino/EspruinoTools/archive/gh-pages.zip), or using git)
 
-### Running in Chromne
+### Running in Chrome
 
 * Install and run the [Chrome Web Browser](https://www.google.com/intl/en/chrome/browser/)
 * Click the menu icon in the top right


### PR DESCRIPTION
It's just a fix of misprint at README.md