### PR TITLE
Add a Web App Manifest

### DIFF
--- a/index.html
+++ b/index.html
@@ -8,6 +8,7 @@
   <meta name=apple-mobile-web-app-status-bar-style content="black">
 
   <link rel="icon" href="favicon.ico">
+  <link rel="manifest" href="webapp_manifest.json">
 
   <link rel="stylesheet" href="css/ui-lightness/jquery-ui-1.10.1.custom.css">
   <link rel="stylesheet" href="css/libs/jquery.treeview.css"></link>

--- a/webapp_manifest.json
+++ b/webapp_manifest.json
@@ -1,0 +1,23 @@
+{
+  "name": "Espruino Web IDE",
+  "short_name": "Espruino IDE",
+  "description": "A Terminal and Graphical code Editor for Espruino JavaScript Microcontrollers",
+  "display": "standalone",
+  "icons": [
+    {
+      "sizes": "128x128",
+      "src": "img/icon_128.png",
+      "type": "image/png"
+    },
+    {
+      "sizes": "256x256",
+      "src": "img/icon_256.png",
+      "type": "image/png"
+    },
+    {
+      "sizes": "512x512",
+      "src": "img/icon_512.png",
+      "type": "image/png"
+    }
+  ]
+}


### PR DESCRIPTION
Adding a [Web App Manifest](https://developer.mozilla.org/en-US/docs/Web/Manifest) allows us to specify a name, short name and icons for users who wish to add the application to their homescreen (or equivalent in various browsers).

The Web App Manifest is similar in some respects to the `manifest.json`, however as the format of images is different it cannot be re-used for this purpose. To keep things clean, I've not re-rendered icons at more optimal sizes. The browser will just choose the best from those available.

Without this PR, users can already choose to add the Web IDE to their homescreen however the properties are assumed by the browser and defaults are chosen where necessary (i.e. the icon).

When PR #172 lands, Chrome should (and others may) recognise the Web IDE as a Progressive Web App (PWA). Based on each browser's own [criteria](https://developers.google.com/web/fundamentals/engage-and-retain/app-install-banners/#what_are_the_criteria), it may proactively offer the user to add the Web IDE to their homes screen.

