### PR TITLE
Minify using google-closure-compiler-js

### DIFF
--- a/main.html
+++ b/main.html
@@ -181,6 +181,7 @@
     <script src="EspruinoTools/libs/utf8.js"></script> <!-- needed for unicode -->
     <script src="EspruinoTools/plugins/unicode.js"></script>
 
+    <script src="EspruinoTools/libs/jscomp.js"></script> <!-- needed for minify, from google-closure-compiler-js -->
     <script src="EspruinoTools/libs/esprima/esprima.js"></script> <!-- needed for minify -->
     <script src="EspruinoTools/libs/esprima/esmangle.js"></script> <!-- needed for minify -->
     <script src="EspruinoTools/libs/esprima/escodegen.js"></script> <!-- needed for minify -->


### PR DESCRIPTION
Notably is adding 3MB of .js code download for the EspruinoWebIDE (800kb if gzipped) proposed to be added in https://github.com/espruino/EspruinoTools/pull/68.

Related to https://github.com/espruino/EspruinoTools/issues/64