### PR TITLE
Increase width of menu

### DIFF
--- a/css/components.css
+++ b/css/components.css
@@ -144,7 +144,7 @@ a:hover > .menu
 {
   display: none;
   position: absolute;
-  width: 180px;
+  width: 230px;
   padding: 10px;
   background: #2c80b9;
   z-index: 2000;


### PR DESCRIPTION
Increasing the width of `.menu` from 180px to 230px stops the _Troubleshooting_ link from spilling onto a second line.

Before:
![image](https://user-images.githubusercontent.com/190127/47295249-1d549e00-d607-11e8-8c93-d45394f077d7.png)

After:
![image](https://user-images.githubusercontent.com/190127/47295137-e41c2e00-d606-11e8-908f-30be60951e12.png)
