### PR TITLE
Add Rollup.js tree-shaking and terser minification

### DIFF
--- a/index.html
+++ b/index.html
@@ -209,6 +209,8 @@
     <script src="EspruinoTools/libs/esprima/esprima.js"></script> <!-- needed for minify -->
     <script src="EspruinoTools/libs/esprima/esmangle.js"></script> <!-- needed for minify -->
     <script src="EspruinoTools/libs/esprima/escodegen.js"></script> <!-- needed for minify -->
+    <script src="EspruinoTools/libs/rollup/espruino-rollup.browser.js"></script> <!-- needed for rollup/terser -->
+    <script src="EspruinoTools/libs/rollup/index.js"></script> <!-- needed for rollup/terser -->
     <script src="EspruinoTools/plugins/minify.js"></script>
 
     <script src="EspruinoTools/plugins/saveOnSend.js"></script> <!-- This should come after minify -->

--- a/js/sandbox-rollup.js
+++ b/js/sandbox-rollup.js
@@ -1,0 +1,13 @@
+sandbox.id = 'rollup';
+sandbox.wrap('Espruino.Core.Utils.getURL', url => new Promise((resolve, reject) => {
+    Espruino.Core.Utils.getURL(url, data => data ? resolve(data) : reject(undefined));
+}));
+sandbox.wrap('Espruino.callProcessor', (processor, data) => new Promise((resolve, reject) => {
+    Espruino.callProcessor(processor, data, result => result ? resolve(result) : reject(undefined));
+}));
+
+var rollupWindow = document.getElementById('rollup').contentWindow;
+window.rollupTools = {
+    loadModulesRollup: code => sandbox.invoke(rollupWindow, 'rollupTools.loadModulesRollup', code),
+    minifyCodeTerser: code => sandbox.invoke(rollupWindow, 'rollupTools.minifyCodeTerser', code),
+};

--- a/js/sandbox.js
+++ b/js/sandbox.js
@@ -1,0 +1,91 @@
+function sandboxInvoke(win, fnName, args) {
+    return new Promise((resolve, reject) => {
+        var message = {
+            id: `${sandbox.id}${sandbox.invokeId++}`,
+            command: 'invoke',
+            context: JSON.stringify({
+                Config: Espruino.Config,
+                Core_Env: {
+                    board: Espruino.Core.Env.getBoardData(),
+                    data: Espruino.Core.Env.getData()
+                }
+            }),
+            fnName,
+            args
+        };
+
+        const setupListener = id => {
+            const listener = (event) => {
+                var data = event.data;
+                if (data.id !== id) return;
+
+                window.removeEventListener('message', listener);
+
+                var command = data.command;
+                switch(command) {
+                    case 'resolve':
+                        resolve(JSON.parse(data.result));
+                        break;
+                    case 'reject':
+                        reject(JSON.parse(data.result));
+                        break;
+                }
+            };
+
+            window.addEventListener('message', listener);
+        };
+
+        console.log('sandbox:msg', message.id, message.command, message.fnName, message);
+
+        setupListener(message.id);
+        win.postMessage(message, '*');
+    });
+}
+
+
+function sandboxWrapListener(event) {
+    // 'null' is when originated from the sandboxed iframe
+    var origin = event.origin == 'null' ? '*' : event.origin;
+    var data = event.data;
+    var command = data.command;
+
+    switch(command) {
+        case 'invoke':
+            sandbox.context = JSON.parse(data.context);
+            sandbox.callerWindow = event.source;
+
+            var postReply = (command, result) => {
+                var message = {
+                    id: data.id,
+                    command,
+                    result: JSON.stringify(result)
+                };
+
+                console.log('sandbox:rpl', message.id, message.command, message);
+                sandbox.callerWindow.postMessage(message, origin);
+            };
+
+            sandbox.wrapped[data.fnName](...data.args)
+                .then(result => postReply('resolve', result))
+                .catch(error => postReply('reject',  error.toString()));
+    }
+}
+
+window.addEventListener('message', sandboxWrapListener);
+
+
+var sandbox = {
+    id: 'sandbox',
+    invokeId: 0,
+
+    wrapped: {},
+    callerWindow: window,
+
+    wrap(fnName, fn) {
+        this.wrapped[fnName] = fn;
+        return sandbox;
+    },
+    invoke(win, fnName, ...args) {
+        return sandboxInvoke(win, fnName, args);
+    }
+};

--- a/main.html
+++ b/main.html
@@ -88,6 +88,12 @@
       </div>
 
     </div>
+
+    <iframe id="rollup" src="sandbox.html"></iframe>
+
+    <script src="js/sandbox.js"></script>
+    <script src="js/sandbox-rollup.js"></script>
+
     <script src="js/libs/jquery-1.11.0.js"></script>
     <script src="js/libs/jquery-ui-1.10.1.custom.js"></script>
     <script src="js/libs/jquery.treeview.js"></script>
@@ -193,8 +199,6 @@
     <script src="EspruinoTools/libs/esprima/esprima.js"></script> <!-- needed for minify -->
     <script src="EspruinoTools/libs/esprima/esmangle.js"></script> <!-- needed for minify -->
     <script src="EspruinoTools/libs/esprima/escodegen.js"></script> <!-- needed for minify -->
-    <script src="EspruinoTools/libs/rollup/espruino-rollup.browser.js"></script> <!-- needed for rollup/terser -->
-    <script src="EspruinoTools/libs/rollup/index.js"></script> <!-- needed for rollup/terser -->
     <script src="EspruinoTools/plugins/minify.js"></script>
 
     <script src="EspruinoTools/plugins/saveOnSend.js"></script> <!-- This should come after minify -->

--- a/main.html
+++ b/main.html
@@ -193,6 +193,8 @@
     <script src="EspruinoTools/libs/esprima/esprima.js"></script> <!-- needed for minify -->
     <script src="EspruinoTools/libs/esprima/esmangle.js"></script> <!-- needed for minify -->
     <script src="EspruinoTools/libs/esprima/escodegen.js"></script> <!-- needed for minify -->
+    <script src="EspruinoTools/libs/rollup/espruino-rollup.browser.js"></script> <!-- needed for rollup/terser -->
+    <script src="EspruinoTools/libs/rollup/index.js"></script> <!-- needed for rollup/terser -->
     <script src="EspruinoTools/plugins/minify.js"></script>
 
     <script src="EspruinoTools/plugins/saveOnSend.js"></script> <!-- This should come after minify -->

--- a/manifest.json
+++ b/manifest.json
@@ -22,6 +22,9 @@
     "http://*/",
     "https://*/"
   ],
+  "sandbox": {
+    "pages": ["sandbox.html"]
+  },
   "sockets": { "tcp" : { "connect": "*" } },
   "manifest_version": 2,
   "url_handlers": {

--- a/sandbox.html
+++ b/sandbox.html
@@ -1,0 +1,50 @@
+<!DOCTYPE html>
+<html><!-- sandbox for Chrome Web IDE -->
+<head>
+  <meta charset="utf-8" />
+
+  <title>Espruino Web IDE Sandbox</title>
+</head>
+<body>
+
+    <script src="EspruinoTools/libs/rollup/espruino-rollup.browser.js"></script> <!-- needed for rollup/terser -->
+    <script src="EspruinoTools/libs/rollup/index.js"></script> <!-- needed for rollup/terser -->
+
+    <script src="js/sandbox.js"></script>
+    <script>
+
+    var Espruino = {
+        callProcessor(processor, data, callback) {
+            sandbox.invoke(sandbox.callerWindow, 'Espruino.callProcessor', processor, data)
+              .then(callback)
+              .catch(() => callback(data));
+        },
+        get Config() {
+            return sandbox.context.Config;
+        },
+        Core: {
+            Utils: {
+                getURL(url, callback) {
+                    sandbox.invoke(sandbox.callerWindow, 'Espruino.Core.Utils.getURL', url)
+                      .then(callback)
+                      .catch(() => callback(undefined));
+                }
+            },
+            Env: {
+                getBoardData() {
+                    return sandbox.context.Core_Env.board;
+                },
+                getData() {
+                    return sandbox.context.Core_Env.data;
+                }
+            }
+        }
+    };
+
+    sandbox.id = 'espruino';
+    sandbox.wrap('rollupTools.loadModulesRollup', rollupTools.loadModulesRollup);
+    sandbox.wrap('rollupTools.minifyCodeTerser', rollupTools.minifyCodeTerser);
+
+    </script>
+</body>
+</html>

--- a/upload.html
+++ b/upload.html
@@ -115,6 +115,8 @@
   <script src="EspruinoTools/libs/esprima/esprima.js"></script> <!-- needed for minify -->
   <script src="EspruinoTools/libs/esprima/esmangle.js"></script> <!-- needed for minify -->
   <script src="EspruinoTools/libs/esprima/escodegen.js"></script> <!-- needed for minify -->
+  <script src="EspruinoTools/libs/rollup/espruino-rollup.browser.js"></script> <!-- needed for rollup/terser -->
+  <script src="EspruinoTools/libs/rollup/index.js"></script> <!-- needed for rollup/terser -->
   <script src="EspruinoTools/plugins/minify.js"></script>
 
   <script src="js/plugins/fontSize.js"></script>


### PR DESCRIPTION
The functionality is off by default so is should not affect users unless they turn on ROLLUP or set (MODULE_)MINIFICATION_LEVEL to TERSER in the IDE settings.

Uses the rollup+terser 907kB browser bundle built into https://github.com/espruino/EspruinoTools/pull/80