### PR TITLE
Service worker references the wrong web app manifest

### DIFF
--- a/serviceworker.js
+++ b/serviceworker.js
@@ -1,5 +1,5 @@
 // Service worker for Offline Web IDE
-const VERSION = 'v78';
+const VERSION = 'v79';
 
 const CACHED_RESOURCES = [
   'blockly/blockly_espruino.js',
@@ -97,7 +97,7 @@ const CACHED_RESOURCES = [
   'img/icon_youtube.png',
   'img/ide_logo.png',
   'favicon.ico',
-  'manifest.json',
+  'ide/webapp_manifest.json',
   'index.js',  // auto-generated file of squished JS
   'index.css', // auto-generated file of squished CSS
   'index.html',


### PR DESCRIPTION
Both exist: https://www.espruino.com/ide/webapp_manifest.json, https://www.espruino.com/ide/manifest.json, but the service worker caches the wrong one. 