### PR TITLE
Added border in bangle emulator

### DIFF
--- a/emu/common.js
+++ b/emu/common.js
@@ -81,6 +81,16 @@ function jsIdle() {
 }
 function jsInit() {
   jsInitButtons();
+
+  var borderColors = ['FFF', 'FF0', 'F00', '000', '00F', '0FF'];
+  var borderColor = 0
+  document.getElementById("border").style.color = '#' + borderColors[(borderColor + 1) % borderColors.length];
+  document.getElementById("border").addEventListener('click', e => {
+    borderColor = ++borderColor % borderColors.length;
+    document.getElementById("gfxcanvas").style.borderColor = '#' + borderColors[borderColor];
+    document.getElementById("border").style.color = '#' + borderColors[(borderColor + 1) % borderColors.length];
+  });
+
   document.getElementById("screenshot").addEventListener('click', e => {
     document.getElementById("screenshot").href = document.getElementById("gfxcanvas").toDataURL();
     document.getElementById("screenshot").download = "screenshot.png";
@@ -159,8 +169,8 @@ console.log("Waiting for posted {type:init} message");
 
 var dontTrigger = false;
 var timerResize;
-var WIN_WIDTH = (GFX_WIDTH+30);
-var WIN_HEIGHT = (GFX_HEIGHT+4);
+var WIN_WIDTH = (GFX_WIDTH+10+30);
+var WIN_HEIGHT = (GFX_HEIGHT+10+4);
 function resizeEnd() {
   //100ms since last resize
   dontTrigger = true;

--- a/emu/emu_banglejs1.html
+++ b/emu/emu_banglejs1.html
@@ -13,16 +13,16 @@
     width:500px; height:500px; border:1px solid black;
   }
   #gfxdiv {
-    position:absolute;top:50%;left:50%;transform:translate(-50%,-50%);width:264px;height:244px;
+    position:absolute;top:50%;left:50%;transform:translate(-50%,-50%);width:274px;height:254px;
   }
   #BTN1 {
-    width:20px;height:73px;position:absolute;right:0px;top:0px;padding:0;font-weight:bold;
+    width:20px;height:63px;position:absolute;right:0px;top:0px;padding:0;font-weight:bold;
   }
   #BTN2 {
-    width:20px;height:73px;position:absolute;right:0px;top:73px;padding:0;font-weight:bold;
+    width:20px;height:63px;position:absolute;right:0px;top:63px;padding:0;font-weight:bold;
   }
   #BTN3 {
-    width:20px;height:73px;position:absolute;right:0px;top:146px;padding:0;font-weight:bold;
+    width:20px;height:63px;position:absolute;right:0px;top:126px;padding:0;font-weight:bold;
   }
   #BTN4 {
     width:125px;height:240px;position:absolute;left:0px;top:0px;padding:0;font-weight:bold;
@@ -30,11 +30,16 @@
   #BTN5 {
     width:125px;height:240px;position:absolute;left:120px;top:0px;padding:0;font-weight:bold;
   }
+  #border {
+    width:20px;height:21px;position:absolute;right:0px;top:193px;color:white;text-decoration:none;background-color:gray;cursor:pointer;
+    font-size: 17px;text-align: center;
+  }
   #screenshot {
     width:20px;height:21px;position:absolute;right:0px;top:219px;color:white;text-decoration:none;background-color:black;cursor:pointer;
   }
   #gfxcanvas {
     image-rendering: pixelated;
+    border: 5px solid #fff;
   }
   </style>
 </head>
@@ -45,6 +50,7 @@
   <button id="BTN1">1</button>
   <button id="BTN2">2</button>
   <button id="BTN3">3</button>
+  <a id="border">&#x05EF;</a>
   <a id="screenshot">&#x1F4F7;</a>
   <div id="BTN4"></div>
   <div id="BTN5"></div>

--- a/emu/emu_banglejs2.html
+++ b/emu/emu_banglejs2.html
@@ -13,16 +13,21 @@
     width:500px; height:500px; border:1px solid black;
   }
   #gfxdiv {
-    position:absolute;top:50%;left:50%;transform:translate(-50%,-50%);width:200px;height:180px;
+    position:absolute;top:50%;left:50%;transform:translate(-50%,-50%);width:210px;height:190px;
   }
   #BTN1 {
-    width:20px;height:73px;position:absolute;right:0px;top:43px;padding:0;font-weight:bold;
+    width:20px;height:63px;position:absolute;right:0px;top:33px;padding:0;font-weight:bold;
+  }
+  #border {
+    width:20px;height:21px;position:absolute;right:0px;top:130px;color:white;text-decoration:none;background-color:gray;cursor:pointer;
+    font-size: 17px;text-align: center;
   }
   #screenshot {
     width:20px;height:21px;position:absolute;right:0px;top:156px;color:white;text-decoration:none;background-color:black;cursor:pointer;
   }
   #gfxcanvas {
     image-rendering: pixelated;
+    border: 5px solid #fff;
   }
   </style>
 </head>
@@ -31,6 +36,7 @@
 <div id="gfxdiv">
   <canvas id="gfxcanvas" width="176" height="176"></canvas>
   <button id="BTN1">1</button>
+  <a id="border">&#x05EF;</a>
   <a id="screenshot">&#x1F4F7;</a>
   <div id="BTN4"></div>
   <div id="BTN5"></div>

--- a/js/plugins/emulator.js
+++ b/js/plugins/emulator.js
@@ -19,14 +19,14 @@ Use embed.js on the client side to link this in.
       description : '240x240 16 bit, 3 buttons',
       link : "https://www.espruino.com/Bangle.js",
       emulatorURL : "/emu/emu_banglejs1.html",
-      emulatorWin : "innerWidth=280,innerHeight=258,location=0"
+      emulatorWin : "innerWidth=290,innerHeight=268,location=0"
     }, {
       id : "BANGLEJS2",
       name : "Bangle.js 2",
       description : '176x176 3 bit, 1 button, full touchscreen',
       link : "https://www.espruino.com/Bangle.js2",
       emulatorURL : "/emu/emu_banglejs2.html",
-      emulatorWin : "innerWidth=280,innerHeight=258,location=0"
+      emulatorWin : "innerWidth=290,innerHeight=268,location=0"
     }
   ];
 


### PR DESCRIPTION
Just a very simple way to have borders on the bangle emulator.
There is a button to cycle through the colors ('FFF', 'FF0', 'F00', '000', '00F', '0FF').
![image](https://user-images.githubusercontent.com/19947640/137218421-fcd1a40d-b224-499d-94ef-85622e673741.png)
