### PR TITLE
Added option to open Bangle.js emulator inside and outside

### DIFF
--- a/package.json
+++ b/package.json
@@ -22,7 +22,8 @@
     "espruino-server": "./server.js"
   },
   "scripts": {
-    "start": "nw ."
+    "start": "nw .",
+    "web": "npx serve"
   },
   "repository": {
     "type": "git",


### PR DESCRIPTION
Added option to open the emulator window inside or as popup window (as already existed / default option).
The inside window can be moved around (draggable). Unfortunately, resizing in not stable. 

![image](https://user-images.githubusercontent.com/19947640/138684460-a8cf986e-c582-4304-9ef0-ed5744674969.png)
![image](https://user-images.githubusercontent.com/19947640/138688013-4e9ecbf5-d126-41f5-8ff0-993aa8f62066.png)

ps 1: Just a suggestion, we should have some linter and prettier so all the code has same format and error free (as possible).
ps 2: I have an error with "npm start" when clicking in "sending to espruino". I develop this with "npm run web", please test on your side if this works with "npm start".

Question: Where are you going with this editor? Are you planning to evolve it or is to be replaced in a near future?
 
