### PR TITLE
Fix changes to editor settings not working

### DIFF
--- a/js/core/editorJavaScript.js
+++ b/js/core/editorJavaScript.js
@@ -107,7 +107,7 @@
     dirty : bool // was changed but not visible
     remove : function to remove
     setVisible : function(bool)
-    setCode    
+    setCode
   }
   */
   function createNewEditor() {
@@ -168,8 +168,8 @@
       if (changeObj.origin == "paste") {
         var c = cm.getCursor();
         var code = cm.getValue();
-	      var newcode = Espruino.Core.Utils.fixBrokenCode(code);
-	      if (newcode!=code) {
+        var newcode = Espruino.Core.Utils.fixBrokenCode(code);
+        if (newcode!=code) {
           // Only set if code has changed, as it moves the scrollbar location :(
           cm.setValue(newcode);
           cm.setCursor(c);
@@ -223,7 +223,7 @@
         $(editor.div).show();
       } else
         $(editor.div).hide();
-      if (editor.dirty) 
+      if (editor.dirty)
         setTimeout(function () {
           editor.codeMirror.refresh();
         }, 1);
@@ -348,13 +348,13 @@
     getSelectedCode : () => { // get the currently highlighted bit of code
       var ed = getVisibleEditor();
       return ed ? ed.getSelectedCode() : "";
-    }, 
+    },
     getCodeMirror : () => {
       console.warn("Using Espruino.Core.EditorJavaScript.getCodeMirror - deprecated");
       var ed = getVisibleEditor();
       if (!ed) return undefined;
       return ed.codeMirror
-    }, 
+    },
     hideAll : () => {
       editors.forEach(editor => { if (editor.visible) editor.setVisible(false); });
     },

--- a/js/core/editorJavaScript.js
+++ b/js/core/editorJavaScript.js
@@ -261,7 +261,7 @@
     // default theme css lives in main css and doesn't need an extra sheet loaded
     if (selectedTheme === 'default') {
       if (codeMirrorThemeCSS) {
-        codeMirrorThemeCSS.parentNode.remove(codeMirrorThemeCSS); // remove previous theme css sheet
+        codeMirrorThemeCSS.remove(); // remove previous theme css sheet
       }
     }else{
       selectedTheme = selectedTheme.replace(/solarized\s(dark|light)/, 'solarized'); // edge case for solarized theme: 1 sheet for both themes

--- a/js/core/editorJavaScript.js
+++ b/js/core/editorJavaScript.js
@@ -90,7 +90,7 @@
       if (js_beautify) {
         var cm = this;
         cm.setValue(js_beautify(cm.getValue(), {
-          indent_size: codeMirror.getOption('tabSize'),
+          indent_size: Espruino.Config.TAB_SIZE,
         }));
       }
     });

--- a/js/core/editorJavaScript.js
+++ b/js/core/editorJavaScript.js
@@ -29,8 +29,8 @@
       type : { "emacs": "Emacs", "vim": "Vim", "sublime": "Sublime" },
       defaultValue : "sublime",
       onChange : function(newValue) {
-        if (codeMirror) {
-          codeMirror.setOption('keyMap', Espruino.Config.KEYMAP);
+        for (const ed of Espruino.Core.EditorJavaScript.getEditors()) {
+          ed.codeMirror.setOption('keyMap', Espruino.Config.KEYMAP);
         }
       }
     });
@@ -41,9 +41,9 @@
       type : { "default": "default", "3024-day": "3024-day", "3024-night": "3024-night", "abcdef": "abcdef", "ambiance": "ambiance", "ayu-dark": "ayu-dark", "ayu-mirage": "ayu-mirage", "base16-dark": "base16-dark", "base16-light": "base16-light", "bespin": "bespin", "blackboard": "blackboard", "cobalt": "cobalt", "colorforth": "colorforth", "darcula": "darcula", "dracula": "dracula", "duotone-dark": "duotone-dark", "duotone-light": "duotone-light", "eclipse": "eclipse", "elegant": "elegant", "espruino": "espruino", "erlang-dark": "erlang-dark", "gruvbox-dark": "gruvbox-dark", "hopscotch": "hopscotch", "icecoder": "icecoder", "idea": "idea", "isotope": "isotope", "lesser-dark": "lesser-dark", "liquibyte": "liquibyte", "lucario": "lucario", "material": "material", "material-darker": "material-darker", "material-palenight": "material-palenight", "material-ocean": "material-ocean", "mbo": "mbo", "mdn-like": "mdn-like", "midnight": "midnight", "monokai": "monokai", "moxer": "moxer", "neat": "neat", "neo": "neo", "night": "night", "nord": "nord", "oceanic-next": "oceanic-next", "panda-syntax": "panda-syntax", "paraiso-dark": "paraiso-dark", "paraiso-light": "paraiso-light", "pastel-on-dark": "pastel-on-dark", "railscasts": "railscasts", "rubyblue": "rubyblue", "seti": "seti", "shadowfox": "shadowfox", "solarized dark": "solarized dark", "solarized light": "solarized light", "the-matrix": "the-matrix", "tomorrow-night-bright": "tomorrow-night-bright", "tomorrow-night-eighties": "tomorrow-night-eighties", "ttcn": "ttcn", "twilight": "twilight", "vibrant-ink": "vibrant-ink", "xq-dark": "xq-dark", "xq-light": "xq-light", "yeti": "yeti", "yonce": "yonce", "zenburn": "zenburn" },
       defaultValue : "default",
       onChange : function(newValue) {
-        if (codeMirror) {
-          loadThemeCSS(Espruino.Config.THEME);
-          codeMirror.setOption('theme', Espruino.Config.THEME);
+        loadThemeCSS(Espruino.Config.THEME);
+        for (const ed of Espruino.Core.EditorJavaScript.getEditors()) {
+          ed.codeMirror.setOption('theme', Espruino.Config.THEME);
         }
       }
     });
@@ -54,8 +54,8 @@
       type : { "spaces": "Spaces", "tabs": "Tabs" },
       defaultValue : "spaces",
       onChange : function(newValue) {
-        if (codeMirror) {
-          codeMirror.setOption('indentWithTabs', !!(Espruino.Config.INDENTATION_TYPE == "tabs"));
+        for (const ed of Espruino.Core.EditorJavaScript.getEditors()) {
+          ed.codeMirror.setOption('indentWithTabs', !!(Espruino.Config.INDENTATION_TYPE == "tabs"));
         }
       }
     });
@@ -66,9 +66,9 @@
       type : {1:1,2:2,4:4,8:8},
       defaultValue : 2,
       onChange : function(newValue) {
-        if (codeMirror) {
-          codeMirror.setOption('tabSize', Espruino.Config.TAB_SIZE);
-          codeMirror.setOption('indentUnit', Espruino.Config.TAB_SIZE);
+        for (const ed of Espruino.Core.EditorJavaScript.getEditors()) {
+          ed.codeMirror.setOption('tabSize', Espruino.Config.TAB_SIZE);
+          ed.codeMirror.setOption('indentUnit', Espruino.Config.TAB_SIZE);
         }
       }
     });
@@ -81,9 +81,9 @@
       type : "boolean",
       defaultValue : false,
       onChange: function(newValue) {
-          if (codeMirror) {
-            codeMirror.setOption('lint', (Espruino.Config.DISABLE_CODE_HINTS) ? false : defaultLintFlags);
-          }
+        for (const ed of Espruino.Core.EditorJavaScript.getEditors()) {
+          ed.codeMirror.setOption('lint', (Espruino.Config.DISABLE_CODE_HINTS) ? false : defaultLintFlags);
+        }
       }
     });
     CodeMirror.defineExtension('beautify', function () {


### PR DESCRIPTION
Fixes issues with editor settings not working when changed, as discussed in #280 and #281.

With this changeset, the IDE options in Settings > General for JavaScript editor keymap, theme, indentation type and size, and code hints should now take effect immediately when changed and should be remembered when the page is reloaded.