### PR TITLE
Fix visual glitches in code editor when switching tabs

### DIFF
--- a/js/core/editorJavaScript.js
+++ b/js/core/editorJavaScript.js
@@ -221,13 +221,12 @@
           }
         });
         $(editor.div).show();
-      } else
-        $(editor.div).hide();
-      if (editor.dirty)
         setTimeout(function () {
           editor.codeMirror.refresh();
         }, 1);
-        editor.dirty = false;
+      } else
+        $(editor.div).hide();
+      editor.dirty = false;
     };
     editor.setCode = function(code) {
       editor.codeMirror.setValue(code);

--- a/js/core/editorJavaScript.js
+++ b/js/core/editorJavaScript.js
@@ -104,7 +104,6 @@
     div : DOM element of outer div
     codeMirror : codemirror instance
     visible : bool
-    dirty : bool // was changed but not visible
     remove : function to remove
     setVisible : function(bool)
     setCode
@@ -113,7 +112,6 @@
   function createNewEditor() {
     var editor = {
       id : "code" + (id++),
-      dirty : false,
       visible : true
     };
 
@@ -226,12 +224,9 @@
         }, 1);
       } else
         $(editor.div).hide();
-      editor.dirty = false;
     };
     editor.setCode = function(code) {
       editor.codeMirror.setValue(code);
-      //if (!this.visible)
-      editor.dirty = true;
     };
     editor.getCode = function() {
       var code = editor.codeMirror.getValue();


### PR DESCRIPTION
Switching between tabs in the IDE code editor was frequently causing a weird display where the line numbers disappeared and half of the code was cut off on the left side of the editor pane. Clicking in the pane restores it to normal, but it happened so much it annoyed me enough to do something about it. :) I believe this fixes the problem.

38e83ede8b3c5e2b27c469070335c8b165de6526 makes sure the CodeMirror `refresh` method always gets called when an editor is unhidden (i.e., its tab is selected), as [recommended in the CM docs](https://codemirror.net/5/doc/manual.html#refresh). The original code only called it if the `dirty` attribute was `true`, and did so regardless of whether it was being shown or hidden (but I'm not sure why a refresh would be done if it's going to be hidden anyway).

With that change, I noticed that nothing else seemed to do anything with `dirty` other than setting it, so 559ca9b477d3e55cb8176dc391263c783616a151 boldly removes all references to it to tidy up the code. Feel free to skip this one if you think it's wrong.