### PR TITLE
[JS editor] Fix bad auto-indentation after #282

### DIFF
--- a/js/core/editorJavaScript.js
+++ b/js/core/editorJavaScript.js
@@ -67,8 +67,8 @@
       defaultValue : 2,
       onChange : function(newValue) {
         for (const ed of Espruino.Core.EditorJavaScript.getEditors()) {
-          ed.codeMirror.setOption('tabSize', Espruino.Config.TAB_SIZE);
-          ed.codeMirror.setOption('indentUnit', Espruino.Config.TAB_SIZE);
+          ed.codeMirror.setOption('tabSize', Number(Espruino.Config.TAB_SIZE));
+          ed.codeMirror.setOption('indentUnit', Number(Espruino.Config.TAB_SIZE));
         }
       }
     });
@@ -90,7 +90,7 @@
       if (js_beautify) {
         var cm = this;
         cm.setValue(js_beautify(cm.getValue(), {
-          indent_size: Espruino.Config.TAB_SIZE,
+          indent_size: Number(Espruino.Config.TAB_SIZE),
         }));
       }
     });
@@ -134,8 +134,8 @@
       keyMap: Espruino.Config.KEYMAP,
       theme: Espruino.Config.THEME,
       indentWithTabs: !!(Espruino.Config.INDENTATION_TYPE == "tabs"),
-      tabSize: Espruino.Config.TAB_SIZE,
-      indentUnit: Espruino.Config.TAB_SIZE,
+      tabSize: Number(Espruino.Config.TAB_SIZE),
+      indentUnit: Number(Espruino.Config.TAB_SIZE),
       extraKeys: {
         "Tab" : function(cm) {
           if (cm.somethingSelected()) {


### PR DESCRIPTION
Quick fix for an indentation problem in the JS editor that I discovered sometime after my work in #282. It's pretty weird; it seems to work fine at first, but after a few nested levels of code it suddenly wants to indent way too much for no apparent reason.

Turns out CodeMirror gets confused apparently if the tab/indent size settings are set to strings rather than numbers. But they get stored as strings in `Espruino.Core.Config` when the option is changed due to the way the settings UI works, I guess. Confusingly, the default option (when you open the IDE for the first time in a browser) is a proper Number, so it works fine, until you try changing the tab size, then it acts up thereafter because the setting value somehow gets converted to String and passed to CodeMirror verbatim.

This patch just takes the easiest way out by converting the setting to a number everywhere the option is passed to a CodeMirror object so that it works correctly whether the value in `Espruino.Core.Config` is String or Number. Might not be perfectly ideal for future code maintenance (we'd have to remember to do that every time), but seems to solve the symptom for now.