### PR TITLE
Work around HTML escaping issues with certain settings

### DIFF
--- a/js/core/menuSettings.js
+++ b/js/core/menuSettings.js
@@ -192,7 +192,7 @@
       } else {
         html += '<select name="'+configName+'" style="float: right;">';
         for (var key in config.type)
-          html += '<option value="'+Espruino.Core.Utils.escapeHTML(key)+'" '+(key==value?"selected":"")+'>'+
+          html += '<option value="'+Espruino.Core.Utils.escapeHTML(key, false)+'" '+(key==value?"selected":"")+'>'+
                     Espruino.Core.Utils.escapeHTML(config.type[key])+
                   '</option>';
         html += '</select>';


### PR DESCRIPTION
This PR was initially meant to correct a small bug with the UI for the JavaScript editor theme setting: If either of the two Solarized themes is chosen by the user, they work, but bringing up the Settings dialog later will show the default theme as selected instead of the actual theme in use.

Unfortunately, properly fixing the underlying cause looks nontrivial, and I'm not sure of the right way to do it. The root cause is that the setting values used for the Solarized themes have spaces in them (this is the form that CodeMirror requires for recognizing them), but the Settings UI escapes spaces by turning them into non-breaking spaces, in addition to also escaping other HTML characters so they can be injected into the webpage. Unfortunately, it looks like it then returns the *escaped* values instead of the original ones back to the code, which ends up storing them into the Espruino settings object. Most settings don't get changed by escaping, so they work, but any that do (like the Solarized settings) end up breaking.

Bizarrely, the Solarized themes still work in the editor despite being passed into CodeMirror with the improper NBSP instead of a real space. I have no idea how. But the UI breaks slightly as described above, and I would expect any other settings in the system (if they exist) which rely on escaped chars in their option values to break.

For now, this works around the issue by passing the `Espruino.Core.Utils.escapeHTML` argument not to convert spaces to NBSPs for the `<option value="…">` part of the page markup, which allows values with spaces to be returned correctly. But this won't work for the other escapable characters. I'm not aware at the moment of any settings that use such characters, but if they exist or ever get added then they likely won't work correctly.