### PR TITLE
close emulator window upon refresh

### DIFF
--- a/emu/common.js
+++ b/emu/common.js
@@ -8,6 +8,7 @@ var maxFlashMemory = 0;
 flashMemory.fill(255);
 
 if ("undefined" != typeof window) {
+  if (window.opener.emu === undefined) window.close();
   if (window.localStorage) {
     let s = localStorage.getItem("BANGLE_STORAGE");
     if (s!=null) {


### PR DESCRIPTION
When opening the emulator from bangle app test links, I noticed it would sometimes not work.  After digging into the code, the emulator window was not closing after refresh or edit url in same tab, thus never able to re-intiate.

After implementing "unload" event for the main window, to close the emulator window via emu/device var.  It didn't close the emulator window, if the emulator window has since been refreshed its-self, this is because the windowId changes and thus it becomes more isolated from the parent.  So I decided that it can just close its-self, if it can detect that it was loaded by its-self.

This is intended to make emulator usage more reliable and less hassle for the user.