### PR TITLE
webIDE support for custom macro buttons

### DIFF
--- a/index.html
+++ b/index.html
@@ -248,6 +248,7 @@
     <script src="js/plugins/keyShortcuts.js"></script>
     <script src="js/plugins/terminalLogger.js"></script>
     <script src="js/plugins/android.js"></script> <!-- Onscreen buttons when running on Android -->
+    <script src="js/plugins/macroButtons.js"></script>
     <!-- js/plugins/_examplePlugin.js -->
 
 <!-- Google tag (gtag.js) -->

--- a/js/plugins/macroButtons.js
+++ b/js/plugins/macroButtons.js
@@ -73,11 +73,11 @@
     var m = macros[index];
 
     var contents =
-      '<div style="padding:10px 15px;">' +
+      '<div style="padding:10px;">' +
         '<label style="display:block;margin-bottom:4px;font-weight:bold;">Name:</label>' +
-        '<input id="macro-cfg-name" type="text" maxlength="15" value="" style="width:calc(100% - 4px);padding:4px;margin-bottom:10px;margin-left:2px;box-sizing:border-box;" />' +
+        '<input id="macro-cfg-name" type="text" maxlength="15" value="" size="30" style="border:2px solid #ccc;margin-bottom:10px;" />' +
         '<label style="display:block;margin-bottom:4px;font-weight:bold;">Script (sent to Espruino on click):</label>' +
-        '<textarea id="macro-cfg-script" rows="6" style="width:calc(100% - 4px);padding:4px;margin-left:2px;box-sizing:border-box;font-family:monospace;font-size:13px;resize:vertical;"></textarea>' +
+        '<textarea id="macro-cfg-script" rows="6" cols="30" style="border:2px solid #ccc;font-family:monospace;font-size:13px;resize:vertical;"></textarea>' +
       '</div>' +
       '<style>.guiders_buttons_container { height: auto !important; display: flex; flex-wrap: wrap; gap: 4px; justify-content: flex-end; } .guiders_buttons_container .guiders_button { padding: 6px 12px; font-size: 13px; }</style>';
 

--- a/js/plugins/macroButtons.js
+++ b/js/plugins/macroButtons.js
@@ -73,18 +73,20 @@
     var m = macros[index];
 
     var contents =
-      '<div style="padding:10px;">' +
+      '<div style="padding:10px 15px;">' +
         '<label style="display:block;margin-bottom:4px;font-weight:bold;">Name:</label>' +
-        '<input id="macro-cfg-name" type="text" value="" style="width:100%;padding:4px;margin-bottom:10px;box-sizing:border-box;" />' +
+        '<input id="macro-cfg-name" type="text" maxlength="15" value="" style="width:100%;padding:4px;margin-bottom:10px;box-sizing:border-box;" />' +
         '<label style="display:block;margin-bottom:4px;font-weight:bold;">Script (sent to Espruino on click):</label>' +
         '<textarea id="macro-cfg-script" rows="6" style="width:100%;padding:4px;box-sizing:border-box;font-family:monospace;font-size:13px;resize:vertical;"></textarea>' +
-      '</div>';
+      '</div>' +
+      '<style>.guiders_buttons_container { height: auto !important; display: flex; flex-wrap: wrap; gap: 4px; justify-content: flex-end; } .guiders_buttons_container .guiders_button { padding: 6px 12px; font-size: 13px; }</style>';
 
     var buttons = [
       { name: "Save", callback: function() {
         var nameInput = document.getElementById("macro-cfg-name");
         var scriptInput = document.getElementById("macro-cfg-script");
-        macros[index].name = nameInput.value || ("Macro " + (index + 1));
+        var name = (nameInput.value || ("Macro " + (index + 1))).substring(0, 15);
+        macros[index].name = name;
         macros[index].script = scriptInput.value;
         setMacros(macros);
         popup.close();

--- a/js/plugins/macroButtons.js
+++ b/js/plugins/macroButtons.js
@@ -1,9 +1,9 @@
 /**
  * Macro Buttons Plugin for Espruino Web IDE
  *
- * Adds a single "Macros" icon to the terminal sidebar. Clicking it
- * opens a popup listing user-configurable macros — tap one to send
- * its script to the connected Espruino device.
+ * Adds a single "Macros" icon to the terminal sidebar. Hover to
+ * see a menu of macros for quick execution, or click the icon to
+ * open a popup for managing macros.
  *
  * This Source Code Form is subject to the terms of the Mozilla Public
  * License, v. 2.0. If a copy of the MPL was not distributed with this
@@ -44,6 +44,21 @@
     Espruino.Core.Serial.write(cmd);
   }
 
+  function buildMenuItems() {
+    var macros = getMacros();
+    return macros.map(function(m, idx) {
+      return {
+        id: "macro-" + idx,
+        icon: "lightning",
+        title: m.name,
+        order: idx,
+        click: function() {
+          sendScript(m.script);
+        }
+      };
+    });
+  }
+
   function showConfigPopup(index) {
     var macros = getMacros();
     var isNew = (index === undefined);
@@ -73,6 +88,7 @@
         macros[index].script = scriptInput.value;
         setMacros(macros);
         popup.close();
+        recreateIcon();
         showMacroList();
       }},
       { name: "Cancel", callback: function() {
@@ -85,6 +101,7 @@
         macros.splice(index, 1);
         setMacros(macros);
         popup.close();
+        recreateIcon();
         showMacroList();
       }});
     }
@@ -143,13 +160,8 @@
   }
 
   function init() {
-    Espruino.Core.Config.addSection("Macro Buttons", {
-      sortOrder: 500,
-      description: "Configurable macro buttons for sending quick commands to Espruino"
-    });
-
     Espruino.Core.Config.add("MACRO_ENABLED", {
-      section: "Macro Buttons",
+      section: "General",
       name: "Enable Macro Buttons",
       description: "Show a Macros icon in the terminal sidebar with quick-send script buttons",
       type: "boolean",
@@ -164,7 +176,7 @@
     });
 
     Espruino.Core.Config.add("MACRO_SCRIPTS", {
-      section: "Macro Buttons",
+      section: "General",
       name: "Macro Scripts (JSON)",
       description: "JSON array of macro objects with name and script fields. Edited via the Macros popup.",
       type: "string",
@@ -185,7 +197,8 @@
       area: { name: "terminal", position: "top" },
       click: function() {
         showMacroList();
-      }
+      },
+      menu: buildMenuItems()
     });
   }
 
@@ -194,6 +207,12 @@
       icon.remove();
       icon = undefined;
     }
+  }
+
+  function recreateIcon() {
+    if (!icon) return;
+    removeIcon();
+    createIcon();
   }
 
   Espruino.Plugins.MacroButtons = {

--- a/js/plugins/macroButtons.js
+++ b/js/plugins/macroButtons.js
@@ -1,0 +1,207 @@
+/**
+ * Macro Buttons Plugin for Espruino Web IDE
+ *
+ * Adds a single "Macros" icon to the terminal sidebar. Clicking it
+ * opens a popup listing user-configurable macros — tap one to send
+ * its script to the connected Espruino device.
+ *
+ * Copyright (C) 2025 Jean-Philippe Rey
+ *
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ */
+"use strict";
+(function() {
+
+  var MAX_MACROS = 10;
+  var icon;
+
+  var defaults = [
+    { name: "Load", script: "load();\n" }
+  ];
+
+  function getMacros() {
+    var raw = Espruino.Config.MACRO_SCRIPTS;
+    if (raw) {
+      try {
+        var parsed = JSON.parse(raw);
+        if (Array.isArray(parsed) && parsed.length > 0)
+          return parsed;
+      } catch(e) {}
+    }
+    return defaults.map(function(d) {
+      return { name: d.name, script: d.script };
+    });
+  }
+
+  function setMacros(macros) {
+    Espruino.Config.set("MACRO_SCRIPTS", JSON.stringify(macros));
+  }
+
+  function sendScript(script) {
+    if (!script) return;
+    var cmd = script.replace(/\r\n/g, "\n");
+    if (cmd[cmd.length - 1] !== "\n") cmd += "\n";
+    Espruino.Core.Serial.write(cmd);
+  }
+
+  function showConfigPopup(index) {
+    var macros = getMacros();
+    var isNew = (index === undefined);
+    if (isNew) {
+      if (macros.length >= MAX_MACROS) {
+        Espruino.Core.Notifications.error("Maximum of " + MAX_MACROS + " macros reached.");
+        return;
+      }
+      index = macros.length;
+      macros.push({ name: "Macro " + (index + 1), script: "" });
+    }
+    var m = macros[index];
+
+    var contents =
+      '<div style="padding:10px;">' +
+        '<label style="display:block;margin-bottom:4px;font-weight:bold;">Name:</label>' +
+        '<input id="macro-cfg-name" type="text" value="" style="width:100%;padding:4px;margin-bottom:10px;box-sizing:border-box;" />' +
+        '<label style="display:block;margin-bottom:4px;font-weight:bold;">Script (sent to Espruino on click):</label>' +
+        '<textarea id="macro-cfg-script" rows="6" style="width:100%;padding:4px;box-sizing:border-box;font-family:monospace;font-size:13px;resize:vertical;"></textarea>' +
+      '</div>';
+
+    var buttons = [
+      { name: "Save", callback: function() {
+        var nameInput = document.getElementById("macro-cfg-name");
+        var scriptInput = document.getElementById("macro-cfg-script");
+        macros[index].name = nameInput.value || ("Macro " + (index + 1));
+        macros[index].script = scriptInput.value;
+        setMacros(macros);
+        popup.close();
+        showMacroList();
+      }},
+      { name: "Cancel", callback: function() {
+        popup.close();
+      }}
+    ];
+
+    if (!isNew) {
+      buttons.push({ name: "Delete", callback: function() {
+        macros.splice(index, 1);
+        setMacros(macros);
+        popup.close();
+        showMacroList();
+      }});
+    }
+
+    var popup = Espruino.Core.App.openPopup({
+      title: isNew ? "New Macro" : "Configure Macro: " + m.name,
+      contents: contents,
+      position: "center",
+      buttons: buttons
+    });
+
+    var nameInput = document.getElementById("macro-cfg-name");
+    var scriptInput = document.getElementById("macro-cfg-script");
+    nameInput.value = m.name;
+    scriptInput.value = m.script;
+    nameInput.focus();
+  }
+
+  function showMacroList() {
+    var macros = getMacros();
+
+    var listItems = macros.map(function(m, idx) {
+      var preview = m.script.replace(/\n/g, " ").trim();
+      if (preview.length > 50) preview = preview.substring(0, 50) + "...";
+      return {
+        icon: "icon-lightning",
+        title: Espruino.Core.Utils.escapeHTML(m.name),
+        description: Espruino.Core.Utils.escapeHTML(preview),
+        callback: function() {
+          popup.close();
+          sendScript(m.script);
+        },
+        right: [{
+          icon: "icon-wrench",
+          title: "Edit",
+          callback: function() {
+            popup.close();
+            showConfigPopup(idx);
+          }
+        }]
+      };
+    });
+
+    // "Add Macro" item at the end
+    listItems.push({
+      icon: "icon-plus",
+      title: "Add Macro...",
+      callback: function() {
+        popup.close();
+        showConfigPopup(undefined);
+      }
+    });
+
+    var popup = Espruino.Core.App.openPopup({
+      title: "Macros",
+      contents: Espruino.Core.HTML.domList(listItems),
+      position: "center"
+    });
+  }
+
+  function init() {
+    Espruino.Core.Config.addSection("Macro Buttons", {
+      sortOrder: 500,
+      description: "Configurable macro buttons for sending quick commands to Espruino"
+    });
+
+    Espruino.Core.Config.add("MACRO_ENABLED", {
+      section: "Macro Buttons",
+      name: "Enable Macro Buttons",
+      description: "Show a Macros icon in the terminal sidebar with quick-send script buttons",
+      type: "boolean",
+      defaultValue: false,
+      onChange: function(newValue) {
+        if (newValue) {
+          createIcon();
+        } else {
+          removeIcon();
+        }
+      }
+    });
+
+    Espruino.Core.Config.add("MACRO_SCRIPTS", {
+      section: "Macro Buttons",
+      name: "Macro Scripts (JSON)",
+      description: "JSON array of macro objects with name and script fields. Edited via the Macros popup.",
+      type: "string",
+      defaultValue: JSON.stringify(defaults)
+    });
+
+    if (Espruino.Config.MACRO_ENABLED)
+      createIcon();
+  }
+
+  function createIcon() {
+    if (icon) return;
+    icon = Espruino.Core.App.addIcon({
+      id: "macroBtn",
+      icon: "lightning",
+      title: "Macros",
+      order: -90,
+      area: { name: "terminal", position: "top" },
+      click: function() {
+        showMacroList();
+      }
+    });
+  }
+
+  function removeIcon() {
+    if (icon) {
+      icon.remove();
+      icon = undefined;
+    }
+  }
+
+  Espruino.Plugins.MacroButtons = {
+    init: init
+  };
+}());

--- a/js/plugins/macroButtons.js
+++ b/js/plugins/macroButtons.js
@@ -41,7 +41,9 @@
     if (!script) return;
     var cmd = script.replace(/\r\n/g, "\n");
     if (cmd[cmd.length - 1] !== "\n") cmd += "\n";
-    Espruino.Core.Serial.write(cmd);
+    Espruino.Core.MenuPortSelector.ensureConnected(function() {
+      Espruino.Core.Serial.write(cmd);
+    });
   }
 
   function buildMenuItems() {

--- a/js/plugins/macroButtons.js
+++ b/js/plugins/macroButtons.js
@@ -112,7 +112,6 @@
       var preview = m.script.replace(/\n/g, " ").trim();
       if (preview.length > 50) preview = preview.substring(0, 50) + "...";
       return {
-        icon: "icon-lightning",
         title: Espruino.Core.Utils.escapeHTML(m.name),
         description: Espruino.Core.Utils.escapeHTML(preview),
         callback: function() {
@@ -120,7 +119,7 @@
           sendScript(m.script);
         },
         right: [{
-          icon: "icon-wrench",
+          icon: "icon-settings",
           title: "Edit",
           callback: function() {
             popup.close();

--- a/js/plugins/macroButtons.js
+++ b/js/plugins/macroButtons.js
@@ -5,8 +5,6 @@
  * opens a popup listing user-configurable macros — tap one to send
  * its script to the connected Espruino device.
  *
- * Copyright (C) 2025 Jean-Philippe Rey
- *
  * This Source Code Form is subject to the terms of the Mozilla Public
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/.
@@ -109,27 +107,25 @@
     var macros = getMacros();
 
     var listItems = macros.map(function(m, idx) {
-      var preview = m.script.replace(/\n/g, " ").trim();
-      if (preview.length > 50) preview = preview.substring(0, 50) + "...";
       return {
         title: Espruino.Core.Utils.escapeHTML(m.name),
-        description: Espruino.Core.Utils.escapeHTML(preview),
-        callback: function() {
-          popup.close();
-          sendScript(m.script);
-        },
-        right: [{
-          icon: "icon-settings",
-          title: "Edit",
-          callback: function() {
-            popup.close();
-            showConfigPopup(idx);
+        right: [
+          { title: "Run", icon: "icon-deploy",
+            callback: function() {
+              popup.close();
+              sendScript(m.script);
+            }
+          },
+          { title: "Edit", icon: "icon-settings",
+            callback: function() {
+              popup.close();
+              showConfigPopup(idx);
+            }
           }
-        }]
+        ]
       };
     });
 
-    // "Add Macro" item at the end
     listItems.push({
       icon: "icon-plus",
       title: "Add Macro...",

--- a/js/plugins/macroButtons.js
+++ b/js/plugins/macroButtons.js
@@ -75,9 +75,9 @@
     var contents =
       '<div style="padding:10px 15px;">' +
         '<label style="display:block;margin-bottom:4px;font-weight:bold;">Name:</label>' +
-        '<input id="macro-cfg-name" type="text" maxlength="15" value="" style="width:100%;padding:4px;margin-bottom:10px;box-sizing:border-box;" />' +
+        '<input id="macro-cfg-name" type="text" maxlength="15" value="" style="width:calc(100% - 4px);padding:4px;margin-bottom:10px;margin-left:2px;box-sizing:border-box;" />' +
         '<label style="display:block;margin-bottom:4px;font-weight:bold;">Script (sent to Espruino on click):</label>' +
-        '<textarea id="macro-cfg-script" rows="6" style="width:100%;padding:4px;box-sizing:border-box;font-family:monospace;font-size:13px;resize:vertical;"></textarea>' +
+        '<textarea id="macro-cfg-script" rows="6" style="width:calc(100% - 4px);padding:4px;margin-left:2px;box-sizing:border-box;font-family:monospace;font-size:13px;resize:vertical;"></textarea>' +
       '</div>' +
       '<style>.guiders_buttons_container { height: auto !important; display: flex; flex-wrap: wrap; gap: 4px; justify-content: flex-end; } .guiders_buttons_container .guiders_button { padding: 6px 12px; font-size: 13px; }</style>';
 


### PR DESCRIPTION
Adds a Macro Buttons plugin that lets users define quick-send scripts for connected Espruino devices. A single
  "Macros" icon appears in the terminal sidebar (disabled by default, enable via Settings > Macro Buttons).
  Clicking it opens a popup listing all configured macros — tap one to send its script, or use the edit button to
  configure it. Macros are stored via the standard Espruino.Config system. Ships with one default macro (load())
  and supports up to 10 user-defined macros.